### PR TITLE
Minor tweaks to commit line drawing

### DIFF
--- a/PBCommitMessageView.m
+++ b/PBCommitMessageView.m
@@ -18,8 +18,8 @@
 	// draw a vertical line after the given size (used as an indicator
 	// for the first line of the commit message)
     if ([PBGitDefaults commitMessageViewHasVerticalLine]) {
-        float characterWidth = [@" " sizeWithAttributes:[self typingAttributes]].width;
-        float lineWidth = characterWidth * [PBGitDefaults commitMessageViewVerticalLineLength];
+        NSSize characterSize = [@" " sizeWithAttributes:[self typingAttributes]];
+        float lineWidth = characterSize.width * [PBGitDefaults commitMessageViewVerticalLineLength];
 
         [[NSColor lightGrayColor] set];
         float padding = [[self textContainer] lineFragmentPadding];
@@ -27,7 +27,24 @@
         line.origin.x = padding + lineWidth;
         line.origin.y = 0;
         line.size.width = 1;
-        line.size.height = [self bounds].size.height;
+		if ([PBGitDefaults commitMessageViewHasSplitVerticalLine]) {
+			line.size.height = characterSize.height;
+			NSRectFill(line);
+			line.origin.y = characterSize.height;
+			lineWidth = characterSize.width * [PBGitDefaults commitMessageViewSplitVerticalLineLength];
+			line.size.width = padding + lineWidth - line.origin.x;
+			line.size.height = 1;
+			if (line.size.width < 0) {
+				line.origin.x = padding + lineWidth + 1;
+				line.size.width = -line.size.width;
+			}
+			NSRectFill(line);
+			line.origin.x = padding + lineWidth;
+			line.size.width = 1;
+			line.size.height = [self bounds].size.height - characterSize.height;
+		} else {
+			line.size.height = [self bounds].size.height;
+		}
         NSRectFill(line);
     }
 }

--- a/PBGitDefaults.h
+++ b/PBGitDefaults.h
@@ -13,6 +13,8 @@
 
 + (int) commitMessageViewVerticalLineLength;
 + (BOOL) commitMessageViewHasVerticalLine;
++ (int) commitMessageViewSplitVerticalLineLength;
++ (BOOL) commitMessageViewHasSplitVerticalLine;
 + (BOOL) isGistEnabled;
 + (BOOL) isGravatarEnabled;
 + (BOOL) confirmPublicGists;

--- a/PBGitDefaults.m
+++ b/PBGitDefaults.m
@@ -10,8 +10,11 @@
 #import "PBHistorySearchController.h"
 
 #define kDefaultVerticalLineLength 50
+#define kDefaultSplitVerticalLineLength 76
 #define kCommitMessageViewVerticalLineLength @"PBCommitMessageViewVerticalLineLength"
 #define kCommitMessageViewHasVerticalLine @"PBCommitMessageViewHasVerticalLine"
+#define kCommitMessageViewHasSplitVerticalLine @"PBCommitMessageViewHasSplitVerticalLine"
+#define kCommitMessageViewSplitVerticalLineLength @"PBCommitMessageViewSplitVerticalLineLength"
 #define kEnableGist @"PBEnableGist"
 #define kEnableGravatar @"PBEnableGravatar"
 #define kConfirmPublicGists @"PBConfirmPublicGists"
@@ -37,6 +40,10 @@
                       forKey:kCommitMessageViewVerticalLineLength];
     [defaultValues setObject:[NSNumber numberWithBool:YES]
                       forKey:kCommitMessageViewHasVerticalLine];
+	[defaultValues setObject:[NSNumber numberWithInt:kDefaultSplitVerticalLineLength]
+					  forKey:kCommitMessageViewSplitVerticalLineLength];
+	[defaultValues setObject:[NSNumber numberWithBool:NO]
+					  forKey:kCommitMessageViewHasSplitVerticalLine];
 	[defaultValues setObject:[NSNumber numberWithBool:YES]
 			  forKey:kEnableGist];
 	[defaultValues setObject:[NSNumber numberWithBool:YES]
@@ -68,6 +75,16 @@
 + (BOOL) commitMessageViewHasVerticalLine
 {
 	return [[NSUserDefaults standardUserDefaults] boolForKey:kCommitMessageViewHasVerticalLine];
+}
+
++ (int) commitMessageViewSplitVerticalLineLength
+{
+	return [[NSUserDefaults standardUserDefaults] integerForKey:kCommitMessageViewSplitVerticalLineLength];
+}
+
++ (BOOL) commitMessageViewHasSplitVerticalLine
+{
+	return [[NSUserDefaults standardUserDefaults] boolForKey:kCommitMessageViewHasSplitVerticalLine];
 }
 
 + (BOOL) isGistEnabled


### PR DESCRIPTION
The first commit is unambiguously correct. It cleans up the column guide drawing code to draw the line more accurately (instead of 5 pixels off, as it is right now) and to stop relying on the dirty rect as part of its positioning code.

The second commit is something that I really like. It adds the ability to have two separate column guides, one for the first line and one for all subsequent lines. Right now this is kept as a hidden preference that defaults to off, but if accepted then it should be added to the preferences window.
