### PR TITLE
Added clickable commit SHAs in the blame view

### DIFF
--- a/GLFileView.m
+++ b/GLFileView.m
@@ -212,16 +212,16 @@
 				if([commitID length]>8){
 					truncate_c=[commitID substringWithRange:trunc_c];
 				}
-				NSRange trunc={0,30};
+				NSRange trunc={0,22};
 				NSString *truncate_a=author;
-				if([author length]>30){
+				if([author length]>22){
 					truncate_a=[author substringWithRange:trunc];
 				}
 				NSString *truncate_s=summary;
 				if([summary length]>30){
 					truncate_s=[summary substringWithRange:trunc];
 				}
-				NSString *block=[NSString stringWithFormat:@"<td><p class='commit-hash'><a href='' onclick='selectCommit(\"%@\"); return false;'>%@</a></p><p class='author'>%@</p><p class='summary'>%@</p></td>\n<td>\n",commitID,truncate_c,truncate_a,truncate_s];
+				NSString *block=[NSString stringWithFormat:@"<td><p class='author'><a href='' onclick='selectCommit(\"%@\"); return false;'>%@</a> %@</p><p class='summary'>%@</p></td>\n<td>\n",commitID,truncate_c,truncate_a,truncate_s];
 				[headers setObject:block forKey:[header objectAtIndex:0]];
 			}
 			[res appendString:[headers objectForKey:[header objectAtIndex:0]]];

--- a/GLFileView.m
+++ b/GLFileView.m
@@ -194,6 +194,7 @@
 		line=[lines objectAtIndex:i];
 		NSArray *header=[line componentsSeparatedByString:@" "];
 		if([header count]==4){
+			NSString *commitID = (NSString *)[header objectAtIndex:0];
 			int nLines=[(NSString *)[header objectAtIndex:3] intValue];
 			[res appendFormat:@"<tr class='block l%d'>\n",nLines];
 			line=[lines objectAtIndex:++i];
@@ -206,6 +207,11 @@
 						summary=[line stringByReplacingOccurrencesOfString:@"summary" withString:@""];
 					}
 				}
+				NSRange trunc_c={0,7};
+				NSString *truncate_c=commitID;
+				if([commitID length]>8){
+					truncate_c=[commitID substringWithRange:trunc_c];
+				}
 				NSRange trunc={0,30};
 				NSString *truncate_a=author;
 				if([author length]>30){
@@ -215,7 +221,7 @@
 				if([summary length]>30){
 					truncate_s=[summary substringWithRange:trunc];
 				}
-				NSString *block=[NSString stringWithFormat:@"<td><p class='author'>%@</p><p class='summary'>%@</p></td>\n<td>\n",truncate_a,truncate_s];
+				NSString *block=[NSString stringWithFormat:@"<td><p class='commit-hash'><a href='' onclick='selectCommit(\"%@\"); return false;'>%@</a></p><p class='author'>%@</p><p class='summary'>%@</p></td>\n<td>\n",commitID,truncate_c,truncate_a,truncate_s];
 				[headers setObject:block forKey:[header objectAtIndex:0]];
 			}
 			[res appendString:[headers objectForKey:[header objectAtIndex:0]]];

--- a/html/views/blame/blame.js
+++ b/html/views/blame/blame.js
@@ -7,3 +7,7 @@ var showFile = function(txt) {
 	SyntaxHighlighter.highlight();
 	return;
 }
+
+var selectCommit = function(a) {
+	Controller.selectCommit_(a);
+}


### PR DESCRIPTION
A small patch to add clickable commit SHAs in the blame view. Useful for navigating the history of a particular file.
